### PR TITLE
Rename output file in rRNA.sh

### DIFF
--- a/workflows/rRNA.sh
+++ b/workflows/rRNA.sh
@@ -7,7 +7,7 @@ perl /space/users/malber06/mmgenome/scripts/extract.long.hits.from.blast.pl -b t
 echo ""
 echo "Extracting 23S sequences"
 blastn -query /space/users/malber06/Desktop/Databases/silva_lsu_90id/silva.lsu.111.90id.fa -db assembly.fa -num_threads 60 -max_target_seqs 5 -outfmt 6 -evalue 1e-10 -out temp.blast.txt
-perl /space/users/malber06/mmgenome/scripts/extract.long.hits.from.blast.pl -b temp.blast.txt -d assembly.fa -m 500 -o 16S.fa
+perl /space/users/malber06/mmgenome/scripts/extract.long.hits.from.blast.pl -b temp.blast.txt -d assembly.fa -m 500 -o 23S.fa
 
 rm temp.blast.txt
 rm assembly.fa.nhr


### PR DESCRIPTION
The output file for the "Extracting 23S sequences" was named 16S.fa
resulting in overwrite of the actual 16S.fa
