### PR TITLE
More convenient output from mmplot_locator (so it’s easier to copy and paste)

### DIFF
--- a/mmgenome/R/mmplot_locator.R
+++ b/mmgenome/R/mmplot_locator.R
@@ -50,7 +50,7 @@ mmplot_locator <- function(p, sig=3){
   
   if (pi$panel$x_scales[[1]]$trans$name == "log-10") d[,1] <- 10^(d[,1])
   if (pi$panel$y_scales[[1]]$trans$name == "log-10") d[,2] <- 10^(d[,2])
-  show(paste(colnames(d)[1]," = ",list(signif(d[,1],sig))))
-  show(paste(colnames(d)[2]," = ",list(signif(d[,2],sig))))
+  cat(paste0(colnames(d)[1]," = ",list(signif(d[,1],sig)),',\n'))
+  cat(paste0(colnames(d)[2]," = ",list(signif(d[,2],sig)),'\n\n'))
   return(d)
 }


### PR DESCRIPTION
Hi Mads!

I’m using `mmplot_locator` quite a lot, and I think this improvements would make the constant copy and pasting easier ;) Let me know what you think!

Best,
Bela

Example output of current behaviour:

```
[1] "N1_average_coverage  =  c(17.5, 16.6, 25, 24.4)"
[1] "N2_average_coverage  =  c(17.5, 12.5, 11.1, 16.9)"
  N1_average_coverage N2_average_coverage
1            17.47362            17.53019
2            16.63933            12.47095
3            24.95645            11.14407
4            24.43863            16.85083
```

Example output of improved behaviour:

```
N1_average_coverage = c(17.1, 16.7, 24.8, 25),
N2_average_coverage = c(17.4, 12.3, 11.1, 16.7)

  N1_average_coverage N2_average_coverage
1            17.11106            17.37102
2            16.69758            12.28280
3            24.78264            11.07651
4            25.04381            16.69783
```
